### PR TITLE
Accept more data attr values

### DIFF
--- a/__tests__/integration/fixture.js
+++ b/__tests__/integration/fixture.js
@@ -63,6 +63,7 @@ export default `
       <div id="someStuff" data-attribute="blue"></div>
       <div id="moreStuff" data-stonk-id="tusk"></div>
       <div id="evenMoreStuff" data-attr-empty></div>
+      <div data-attr="TestPage/clickable div"></div>
       <div>
           <div>
               <div>

--- a/__tests__/integration/index.test.js
+++ b/__tests__/integration/index.test.js
@@ -309,6 +309,16 @@ test(`can analyze multiple elements with data attributes`, function () {
   expect(elements.selector).toEqual("[data-stonk-id='tusk']")
 })
 
+test(`can analyze an element with data attribute values`, function () {
+  const windowScope = createWindow(fixture)
+  var elements = compareElementsAndSimmer(windowScope, "[data-attr='TestPage/clickable div']")
+  expect(elements).not.toBe(undefined)
+  expect(elements.SimmerEl).not.toBe(undefined)
+  expect(elements.el).not.toBe(undefined)
+  expect(elements.el).toBe(elements.SimmerEl)
+  expect(elements.selector).toEqual("[data-attr='TestPage/clickable div']")
+})
+
 test(`can analyze multiple elements with empty data attribute`, function () {
   const windowScope = createWindow(fixture)
   var elements = compareElementsAndSimmer(windowScope, '#evenMoreStuff')

--- a/modules/methods/inspectDataAttributes.js
+++ b/modules/methods/inspectDataAttributes.js
@@ -30,7 +30,7 @@ export default function (hierarchy, state, validateSelector, config, query) {
           return [key, currentElem.el.getAttribute(key)]
         })
         .filter(
-          ([key, value]) => attr(value) || (key.match(/^data-/) && !value) // data- can be empty
+          ([key, value]) => attr(value) || key.match(/^data-/) // data- can be empty
         )
         .map(([key, value]) => {
           const isUnique = isUniqueDataAttr(query, key, value)


### PR DESCRIPTION
If a data attribute have a value containing `/` or space, it won't be used in the resulting selector.

See the added test case, which would fail with:

```
    Expected: "[data-attr='TestPage/clickable div']"
    Received: "DIV[id='fixture'] > DIV:nth-child(6)"
```

I don't think the validation needs to be this strict since the value would be encoded within a string in the selector.

